### PR TITLE
Fix clippy needless_range_loop warning breaking CI

### DIFF
--- a/src-tauri/src/display.rs
+++ b/src-tauri/src/display.rs
@@ -50,7 +50,7 @@ pub fn build_display(content: &str, match_indices: &[usize]) -> DisplayInfo {
     let mut current_text = String::new();
     let mut current_hl = index_set.contains(&start);
 
-    for i in start..end {
+    for (i, &ch) in chars.iter().enumerate().skip(start).take(end - start) {
         let is_hl = index_set.contains(&i);
         if is_hl != current_hl {
             if !current_text.is_empty() {
@@ -62,7 +62,7 @@ pub fn build_display(content: &str, match_indices: &[usize]) -> DisplayInfo {
             current_text = String::new();
             current_hl = is_hl;
         }
-        current_text.push(chars[i]);
+        current_text.push(ch);
     }
     if !current_text.is_empty() {
         segments.push(DisplaySegment {


### PR DESCRIPTION
## Summary
- Replace manual index-based `for i in start..end` loop with `chars.iter().enumerate().skip(start).take(end - start)` in `display.rs`
- Satisfies clippy's `needless_range_loop` lint, which was causing CI failure due to `-D warnings`

## Test plan
- [ ] Verify CI passes (clippy step no longer fails)
- [ ] Confirm display segmentation behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)