### PR TITLE
refactor: extract cursor state management into useCursor hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,8 +14,7 @@ function App() {
     query,
     setQuery,
     results,
-    selectedIndex,
-    setSelectedIndex,
+    cursor,
     handlePaste,
     handleDelete,
     refreshSearch,
@@ -126,22 +125,22 @@ function App() {
 
     if (matchesKeybinding(e, keybindings.next)) {
       e.preventDefault();
-      setSelectedIndex((i) => (i + 1) % Math.max(results.length, 1));
+      cursor.moveNext(results.length);
     } else if (matchesKeybinding(e, keybindings.prev)) {
       e.preventDefault();
-      setSelectedIndex((i) => (i - 1 + results.length) % Math.max(results.length, 1));
+      cursor.movePrev(results.length);
     } else if (matchesKeybinding(e, keybindings.select)) {
       e.preventDefault();
-      if (results[selectedIndex]) {
-        handlePaste(results[selectedIndex].id);
+      if (results[cursor.selectedIndex]) {
+        handlePaste(results[cursor.selectedIndex].id);
       }
     } else if (matchesKeybinding(e, keybindings.close)) {
       e.preventDefault();
       getCurrentWindow().hide();
     } else if (matchesKeybinding(e, keybindings.delete)) {
-      if (results[selectedIndex] && !results[selectedIndex].pinned) {
+      if (results[cursor.selectedIndex] && !results[cursor.selectedIndex].pinned) {
         e.preventDefault();
-        handleDelete(results[selectedIndex].id);
+        handleDelete(results[cursor.selectedIndex].id);
       }
     } else if (matchesKeybinding(e, keybindings.toggle_theme)) {
       e.preventDefault();
@@ -152,9 +151,9 @@ function App() {
       e.preventDefault();
       invoke("open_config").catch((err) => console.error("Failed to open config:", err));
     } else if (e.ctrlKey && e.key === "f") {
-      if (results[selectedIndex]) {
+      if (results[cursor.selectedIndex]) {
         e.preventDefault();
-        const current = results[selectedIndex];
+        const current = results[cursor.selectedIndex];
         if (current.pinned) {
           await invoke("toggle_pin", { id: current.id, label: "" });
           refreshSearch();
@@ -200,9 +199,9 @@ function App() {
       <div className="results-container">
         <ResultList
           results={results}
-          selectedIndex={selectedIndex}
+          selectedIndex={cursor.selectedIndex}
           onPaste={handlePaste}
-          onSelect={setSelectedIndex}
+          onSelect={cursor.selectByIndex}
           listRef={listRef}
         />
         {showHelp && keybindings && <HelpOverlay keybindings={keybindings} />}

--- a/src/hooks/useClipboardSearch.test.ts
+++ b/src/hooks/useClipboardSearch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { clampIndex } from "./useClipboardSearch";
+import { clampIndex } from "./useCursor";
 
 describe("clampIndex", () => {
   it("preserves index when within bounds", () => {

--- a/src/hooks/useClipboardSearch.ts
+++ b/src/hooks/useClipboardSearch.ts
@@ -3,18 +3,15 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { SearchResult } from "../types";
-
-export function clampIndex(prev: number, length: number): number {
-  return Math.min(prev, Math.max(length - 1, 0));
-}
+import { useCursor } from "./useCursor";
 
 export function useClipboardSearch() {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
-  const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const queryRef = useRef(query);
+  const cursor = useCursor(listRef);
 
   useEffect(() => {
     queryRef.current = query;
@@ -25,9 +22,9 @@ export function useClipboardSearch() {
       const res = await invoke<SearchResult[]>("search_clipboard", { query: q });
       setResults(res);
       if (resetIndex) {
-        setSelectedIndex(0);
+        cursor.reset();
       } else {
-        setSelectedIndex((prev) => clampIndex(prev, res.length));
+        cursor.clamp(res.length);
       }
     } catch (e) {
       console.error("Search failed:", e);
@@ -67,15 +64,6 @@ export function useClipboardSearch() {
     return () => clearTimeout(timer);
   }, [query, search]);
 
-  useEffect(() => {
-    const list = listRef.current;
-    if (!list) return;
-    const item = list.children[selectedIndex] as HTMLElement;
-    if (item) {
-      item.scrollIntoView({ block: "nearest" });
-    }
-  }, [selectedIndex]);
-
   const handlePaste = async (id: number) => {
     try {
       await invoke("paste_entry", { id });
@@ -92,7 +80,7 @@ export function useClipboardSearch() {
         query: queryRef.current,
       });
       setResults(res);
-      setSelectedIndex((prev) => clampIndex(prev, res.length));
+      cursor.clamp(res.length);
     } catch (e) {
       console.error("Delete failed:", e);
     }
@@ -104,8 +92,7 @@ export function useClipboardSearch() {
     query,
     setQuery,
     results,
-    selectedIndex,
-    setSelectedIndex,
+    cursor,
     handlePaste,
     handleDelete,
     refreshSearch,

--- a/src/hooks/useClipboardSearch.ts
+++ b/src/hooks/useClipboardSearch.ts
@@ -17,19 +17,22 @@ export function useClipboardSearch() {
     queryRef.current = query;
   }, [query]);
 
-  const search = useCallback(async (q: string, resetIndex = true) => {
-    try {
-      const res = await invoke<SearchResult[]>("search_clipboard", { query: q });
-      setResults(res);
-      if (resetIndex) {
-        cursor.reset();
-      } else {
-        cursor.clamp(res.length);
+  const search = useCallback(
+    async (q: string, resetIndex = true) => {
+      try {
+        const res = await invoke<SearchResult[]>("search_clipboard", { query: q });
+        setResults(res);
+        if (resetIndex) {
+          cursor.reset();
+        } else {
+          cursor.clamp(res.length);
+        }
+      } catch (e) {
+        console.error("Search failed:", e);
       }
-    } catch (e) {
-      console.error("Search failed:", e);
-    }
-  }, []);
+    },
+    [cursor.reset, cursor.clamp],
+  );
 
   useEffect(() => {
     search("").then(() => {

--- a/src/hooks/useCursor.ts
+++ b/src/hooks/useCursor.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export function clampIndex(prev: number, length: number): number {
   return Math.min(prev, Math.max(length - 1, 0));
@@ -16,16 +16,24 @@ export function useCursor(listRef: React.RefObject<HTMLDivElement | null>) {
     }
   }, [selectedIndex]);
 
-  const reset = () => setSelectedIndex(0);
+  const reset = useCallback(() => setSelectedIndex(0), []);
 
-  const clamp = (length: number) => setSelectedIndex((prev) => clampIndex(prev, length));
+  const clamp = useCallback(
+    (length: number) => setSelectedIndex((prev) => clampIndex(prev, length)),
+    [],
+  );
 
-  const moveNext = (length: number) => setSelectedIndex((i) => (i + 1) % Math.max(length, 1));
+  const moveNext = useCallback(
+    (length: number) => setSelectedIndex((i) => (i + 1) % Math.max(length, 1)),
+    [],
+  );
 
-  const movePrev = (length: number) =>
-    setSelectedIndex((i) => (i - 1 + length) % Math.max(length, 1));
+  const movePrev = useCallback(
+    (length: number) => setSelectedIndex((i) => (i - 1 + length) % Math.max(length, 1)),
+    [],
+  );
 
-  const selectByIndex = (i: number) => setSelectedIndex(i);
+  const selectByIndex = useCallback((i: number) => setSelectedIndex(i), []);
 
   return { selectedIndex, reset, clamp, moveNext, movePrev, selectByIndex };
 }

--- a/src/hooks/useCursor.ts
+++ b/src/hooks/useCursor.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+export function clampIndex(prev: number, length: number): number {
+  return Math.min(prev, Math.max(length - 1, 0));
+}
+
+export function useCursor(listRef: React.RefObject<HTMLDivElement | null>) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const item = list.children[selectedIndex] as HTMLElement;
+    if (item) {
+      item.scrollIntoView({ block: "nearest" });
+    }
+  }, [selectedIndex]);
+
+  const reset = () => setSelectedIndex(0);
+
+  const clamp = (length: number) => setSelectedIndex((prev) => clampIndex(prev, length));
+
+  const moveNext = (length: number) => setSelectedIndex((i) => (i + 1) % Math.max(length, 1));
+
+  const movePrev = (length: number) =>
+    setSelectedIndex((i) => (i - 1 + length) % Math.max(length, 1));
+
+  const selectByIndex = (i: number) => setSelectedIndex(i);
+
+  return { selectedIndex, reset, clamp, moveNext, movePrev, selectByIndex };
+}


### PR DESCRIPTION
## Summary
- カーソル（selectedIndex）の状態管理を `useCursor` hookとして新規ファイルに切り出し
- `useClipboardSearch` と `App.tsx` に散らばっていたカーソル操作ロジックを集約
- `moveNext`, `movePrev`, `reset`, `clamp`, `selectByIndex` のAPIで操作を明確化

## Test plan
- [x] 既存テスト全23件パス（vitest）
- [x] キーボードナビゲーション（next/prev wrap around）
- [x] マウスホバーでの選択
- [x] 検索時のindex reset
- [x] 削除後のindex clamp
- [x] auto-scroll動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)