### PR TITLE
feat: autostart, LICENSE, and bundle metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ open = "Ctrl+Shift+V"
 
 [behavior]
 max_history = 1000
+autostart = false              # launch fclip on Windows login
 
 [theme]
 mode = "system"              # "dark", "light", or "system" (follows OS)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Kohei Wada
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -7,6 +7,7 @@ open = "Ctrl+Shift+V"
 
 [behavior]
 max_history = 1000
+autostart = false              # launch fclip on Windows login
 
 [theme]
 mode = "system"              # "dark", "light", or "system" (follows OS preference at startup)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "private": true,
   "version": "0.5.0",
   "type": "module",
+  "description": "A fast, keyboard-driven clipboard manager for Windows",
+  "author": "Kohei Wada",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kohei-Wada/fclip.git"
+  },
+  "homepage": "https://github.com/Kohei-Wada/fclip",
   "scripts": {
     "dev": "tauri dev",
     "build": "tauri build",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -89,6 +89,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,6 +626,15 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
@@ -629,6 +649,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -763,7 +794,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -840,6 +871,7 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-global-shortcut",
  "thiserror 1.0.69",
  "toml 0.8.2",
@@ -3685,6 +3717,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-global-shortcut"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5071,6 +5117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-global-shortcut = "2"
+tauri-plugin-autostart = "2"
 serde = { version = "1", features = ["derive"] }
 clipboard-win = "5"
 rusqlite = { version = "0.31", features = ["bundled"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,9 @@
     "core:window:allow-hide",
     "core:window:allow-set-focus",
     "core:window:allow-close",
-    "core:window:allow-start-dragging"
+    "core:window:allow-start-dragging",
+    "autostart:allow-enable",
+    "autostart:allow-disable",
+    "autostart:allow-is-enabled"
   ]
 }

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -86,6 +86,7 @@ pub fn run() {
     let db = Arc::new(Database::new(&db_path).expect("Failed to initialize database"));
 
     let max_history = config.behavior.max_history;
+    let autostart = config.behavior.autostart;
     let hotkey = config.hotkey.open.clone();
 
     let state = AppState {
@@ -95,6 +96,10 @@ pub fn run() {
     };
 
     tauri::Builder::default()
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            None,
+        ))
         .manage(state)
         .invoke_handler(tauri::generate_handler![
             commands::search_clipboard,
@@ -114,6 +119,15 @@ pub fn run() {
         .setup(move |app| {
             setup_tray(app)?;
             setup_global_shortcut(app, &hotkey)?;
+
+            use tauri_plugin_autostart::ManagerExt;
+            let autostart_manager = app.autolaunch();
+            if autostart {
+                let _ = autostart_manager.enable();
+                eprintln!("[fclip] Autostart enabled");
+            } else {
+                let _ = autostart_manager.disable();
+            }
 
             let app_handle = app.handle().clone();
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -24,6 +24,8 @@ pub struct HotkeyConfig {
 pub struct BehaviorConfig {
     #[serde(default = "default_max_history")]
     pub max_history: usize,
+    #[serde(default)]
+    pub autostart: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -118,6 +120,7 @@ impl Default for BehaviorConfig {
     fn default() -> Self {
         Self {
             max_history: default_max_history(),
+            autostart: false,
         }
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,11 +31,20 @@
   "bundle": {
     "active": true,
     "targets": ["nsis", "msi"],
+    "copyright": "Copyright (c) 2025 Kohei Wada",
+    "shortDescription": "A fast, keyboard-driven clipboard manager for Windows",
+    "longDescription": "fclip is a minimal, fzf-style clipboard manager that runs in the system tray and provides instant fuzzy-search access to your clipboard history.",
+    "licenseFile": "../LICENSE",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
       "icons/128x128@2x.png",
       "icons/icon.ico"
-    ]
+    ],
+    "windows": {
+      "nsis": {
+        "installMode": "currentUser"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add optional autostart on Windows login via `tauri-plugin-autostart`, controlled by `behavior.autostart` in config.toml (default: false) — Closes #40
- Add MIT LICENSE file — Closes #36
- Add bundle metadata (copyright, descriptions, license, NSIS config) to tauri.conf.json — Closes #37
- Add missing metadata to package.json — Closes #38

## Test plan
- [x] `cargo test` passes all tests
- [ ] `npm run build` succeeds with license displayed in NSIS installer
- [ ] Set `autostart = true` in config.toml, restart PC, confirm fclip launches automatically
- [ ] Set `autostart = false`, restart, confirm fclip does not launch
- [ ] Windows file properties show copyright and description

🤖 Generated with [Claude Code](https://claude.com/claude-code)