### PR TITLE
refactor: extract IPC commands, deduplicate hideWindow, standardize async/await

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { invoke } from "@tauri-apps/api/core";
 import { useClipboardSearch } from "./hooks/useClipboardSearch";
 import { useKeybindings, matchesKeybinding } from "./hooks/useKeybindings";
 import { SearchBar } from "./components/SearchBar";
@@ -8,6 +7,7 @@ import { ResultList } from "./components/ResultList";
 import { StatusBar } from "./components/StatusBar";
 import { HelpOverlay } from "./components/HelpOverlay";
 import { TabBar, type Tab } from "./components/TabBar";
+import { getTheme, togglePin, openConfig, hideWindow } from "./commands";
 import "./App.css";
 
 function App() {
@@ -33,8 +33,9 @@ function App() {
   } = useClipboardSearch(pinnedOnly);
 
   useEffect(() => {
-    invoke<string>("get_theme")
-      .then((mode) => {
+    const loadTheme = async () => {
+      try {
+        const mode = await getTheme();
         let resolved: "dark" | "light";
         if (mode === "system") {
           resolved = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
@@ -43,15 +44,16 @@ function App() {
         }
         setTheme(resolved);
         document.documentElement.dataset.theme = resolved;
-      })
-      .catch((error) => {
+      } catch (error) {
         console.error("Failed to get theme:", error);
         const fallback = window.matchMedia("(prefers-color-scheme: dark)").matches
           ? "dark"
           : "light";
         setTheme(fallback);
         document.documentElement.dataset.theme = fallback;
-      });
+      }
+    };
+    loadTheme();
   }, []);
 
   useEffect(() => {
@@ -72,7 +74,7 @@ function App() {
 
   const confirmPin = async () => {
     if (!pinMode) return;
-    await invoke("toggle_pin", { id: pinMode.id, label: pinLabel });
+    await togglePin(pinMode.id, pinLabel);
     setPinMode(null);
     setPinLabel("");
     refreshSearch();
@@ -136,7 +138,7 @@ function App() {
 
     if (e.ctrlKey && e.key === "[") {
       e.preventDefault();
-      getCurrentWindow().hide();
+      hideWindow();
       return;
     }
 
@@ -165,7 +167,7 @@ function App() {
       }
     } else if (matchesKeybinding(e, keybindings.close)) {
       e.preventDefault();
-      getCurrentWindow().hide();
+      hideWindow();
     } else if (matchesKeybinding(e, keybindings.delete)) {
       if (results[cursor.selectedIndex] && !results[cursor.selectedIndex].pinned) {
         e.preventDefault();
@@ -178,13 +180,13 @@ function App() {
       document.documentElement.dataset.theme = next;
     } else if (matchesKeybinding(e, keybindings.open_config)) {
       e.preventDefault();
-      invoke("open_config").catch((err) => console.error("Failed to open config:", err));
+      openConfig().catch((err) => console.error("Failed to open config:", err));
     } else if (e.ctrlKey && e.key === "f") {
       if (results[cursor.selectedIndex]) {
         e.preventDefault();
         const current = results[cursor.selectedIndex];
         if (current.pinned) {
-          await invoke("toggle_pin", { id: current.id, label: "" });
+          await togglePin(current.id, "");
           refreshSearch();
         } else {
           enterPinMode(current.id);
@@ -199,7 +201,7 @@ function App() {
     <div className="container">
       <div className="drag-handle" data-tauri-drag-region>
         <span className="app-title">fclip v{__APP_VERSION__}</span>
-        <button className="close-btn" onClick={() => getCurrentWindow().hide()}>
+        <button className="close-btn" onClick={() => hideWindow()}>
           ×
         </button>
       </div>

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -18,9 +18,10 @@ export function hideWindow() {
   return getCurrentWindow().hide();
 }
 
-export function showWindow() {
+export async function showWindow() {
   const win = getCurrentWindow();
-  return win.show().then(() => win.setFocus());
+  await win.show();
+  await win.setFocus();
 }
 
 // Typed invoke helpers

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,53 @@
+import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import type { SearchResult, Keybindings } from "./types";
+
+// IPC command names
+export const Commands = {
+  SEARCH_CLIPBOARD: "search_clipboard",
+  PASTE_ENTRY: "paste_entry",
+  DELETE_ENTRY: "delete_entry",
+  TOGGLE_PIN: "toggle_pin",
+  GET_KEYBINDINGS: "get_keybindings",
+  GET_THEME: "get_theme",
+  OPEN_CONFIG: "open_config",
+} as const;
+
+// Window utilities
+export function hideWindow() {
+  return getCurrentWindow().hide();
+}
+
+export function showWindow() {
+  const win = getCurrentWindow();
+  return win.show().then(() => win.setFocus());
+}
+
+// Typed invoke helpers
+export function searchClipboard(query: string, pinnedOnly: boolean | null) {
+  return invoke<SearchResult[]>(Commands.SEARCH_CLIPBOARD, { query, pinnedOnly });
+}
+
+export function pasteEntry(id: number) {
+  return invoke(Commands.PASTE_ENTRY, { id });
+}
+
+export function deleteEntry(id: number) {
+  return invoke(Commands.DELETE_ENTRY, { id });
+}
+
+export function togglePin(id: number, label: string) {
+  return invoke(Commands.TOGGLE_PIN, { id, label });
+}
+
+export function getKeybindings() {
+  return invoke<Keybindings>(Commands.GET_KEYBINDINGS);
+}
+
+export function getTheme() {
+  return invoke<string>(Commands.GET_THEME);
+}
+
+export function openConfig() {
+  return invoke(Commands.OPEN_CONFIG);
+}

--- a/src/hooks/useClipboardSearch.ts
+++ b/src/hooks/useClipboardSearch.ts
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState, useCallback } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { SearchResult } from "../types";
 import { useCursor } from "./useCursor";
+import { searchClipboard, pasteEntry, deleteEntry, hideWindow, showWindow } from "../commands";
 
 export function useClipboardSearch(pinnedOnly: boolean | null) {
   const [query, setQuery] = useState("");
@@ -25,10 +25,7 @@ export function useClipboardSearch(pinnedOnly: boolean | null) {
   const search = useCallback(
     async (q: string, resetIndex = true) => {
       try {
-        const res = await invoke<SearchResult[]>("search_clipboard", {
-          query: q,
-          pinnedOnly: pinnedOnlyRef.current,
-        });
+        const res = await searchClipboard(q, pinnedOnlyRef.current);
         setResults(res);
         if (resetIndex) {
           cursor.reset();
@@ -43,10 +40,11 @@ export function useClipboardSearch(pinnedOnly: boolean | null) {
   );
 
   useEffect(() => {
-    search("").then(() => {
-      getCurrentWindow().show();
-      getCurrentWindow().setFocus();
-    });
+    const init = async () => {
+      await search("");
+      await showWindow();
+    };
+    init();
 
     const unlisten = listen("clipboard-updated", () => {
       search(queryRef.current, false);
@@ -77,8 +75,8 @@ export function useClipboardSearch(pinnedOnly: boolean | null) {
 
   const handlePaste = async (id: number) => {
     try {
-      await invoke("paste_entry", { id });
-      await getCurrentWindow().hide();
+      await pasteEntry(id);
+      await hideWindow();
     } catch (e) {
       console.error("Paste failed:", e);
     }
@@ -86,11 +84,8 @@ export function useClipboardSearch(pinnedOnly: boolean | null) {
 
   const handleDelete = async (id: number) => {
     try {
-      await invoke("delete_entry", { id });
-      const res = await invoke<SearchResult[]>("search_clipboard", {
-        query: queryRef.current,
-        pinnedOnly: pinnedOnlyRef.current,
-      });
+      await deleteEntry(id);
+      const res = await searchClipboard(queryRef.current, pinnedOnlyRef.current);
       setResults(res);
       cursor.clamp(res.length);
     } catch (e) {

--- a/src/hooks/useKeybindings.ts
+++ b/src/hooks/useKeybindings.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import type { Key, Keybindings } from "../types";
+import { getKeybindings } from "../commands";
 
 // Characters that require Shift to type (symbols on number/punctuation keys).
 // When the configured key is one of these, we skip the strict shiftKey check
@@ -22,7 +22,7 @@ export function useKeybindings() {
 
   useEffect(() => {
     const load = async () => {
-      const kb = await invoke<Keybindings>("get_keybindings");
+      const kb = await getKeybindings();
       setKeybindings(kb);
     };
     load();


### PR DESCRIPTION
## Summary
- Add `src/commands.ts` with typed IPC command helpers and `hideWindow()`/`showWindow()` utilities
- Replace all magic string `invoke()` calls with typed functions
- Deduplicate `getCurrentWindow().hide()` calls across App.tsx and useClipboardSearch.ts
- Convert remaining `.then()` callbacks to `async/await`

Closes #8, closes #11, closes #14

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run test:front` passes (23 tests)
- [ ] All keyboard shortcuts work as before (paste, delete, pin, hide, theme toggle, help, config)
- [ ] Window hide/show behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)